### PR TITLE
MemberService Development

### DIFF
--- a/shop/shop/src/main/java/com/min/shop/repository/MemberRepository.java
+++ b/shop/shop/src/main/java/com/min/shop/repository/MemberRepository.java
@@ -3,14 +3,16 @@ package com.min.shop.repository;
 import com.min.shop.domain.Member;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
+@RequiredArgsConstructor
 public class MemberRepository {
-    @PersistenceContext
-    EntityManager em;
+
+    private final EntityManager em;
 
     public void save(Member member) {
         em.persist(member);

--- a/shop/shop/src/main/java/com/min/shop/service/MemberService.java
+++ b/shop/shop/src/main/java/com/min/shop/service/MemberService.java
@@ -1,0 +1,42 @@
+package com.min.shop.service;
+
+import com.min.shop.domain.Member;
+import com.min.shop.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    //회원가입
+    @Transactional
+    public Long join(Member member) {
+        validateDuplicateMember(member); //중복 회원 검증
+        memberRepository.save(member);
+        return member.getId();
+    }
+
+    private void validateDuplicateMember(Member member) {
+        List<Member> findMembers = memberRepository.findByName(member.getName());
+        if (!findMembers.isEmpty()) {
+            throw new IllegalStateException("이미 존재하는 회원입니다.");
+        }
+    }
+
+    //전체 회원 조회
+    public List<Member> findMembers() {
+        return memberRepository.findAll();
+    }
+
+    public Member findOne(Long memberId) {
+        return memberRepository.findOne(memberId);
+    }
+}


### PR DESCRIPTION
기능
join()
findMembers()
findOne()

@Transactional : 트랜잭션, 영속성 컨텍스트
readOnly = true: 데이터의 변경이 없는 읽기 전용 메서드에 사용하고 영속성 컨텍스트를 플러시 하지 않으므로 약간의 성능 향상(읽기 전용에 다 적용)
데이터베이스 드라이버가 지원하면 DB에서 성능 향상

MemberRepository
EntityManager 필드 주입에서 생성자 주입으로 변경