### PR TITLE
Member Test

### DIFF
--- a/shop/shop/src/test/java/com/min/shop/service/MemberServiceTest.java
+++ b/shop/shop/src/test/java/com/min/shop/service/MemberServiceTest.java
@@ -1,0 +1,54 @@
+package com.min.shop.service;
+
+import com.min.shop.domain.Member;
+import com.min.shop.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+
+    @Autowired
+    MemberService memberService;
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    public void join() throws Exception {
+        //given
+        Member member = new Member();
+        member.setName("kim");
+
+        //when
+        Long saveId = memberService.join(member);
+
+        //then
+        assertEquals(member, memberRepository.findOne(saveId));
+    }
+
+    @Test
+    public void duplicate_exception() throws Exception {
+        //given
+        Member member1 = new Member();
+        member1.setName("min");
+
+        Member member2 = new Member();
+        member2.setName("min");
+
+        //when
+//        memberService.join(member1);
+//        memberService.join(member2); //예외 발생
+
+        //then
+        assertThrows(IllegalStateException.class,
+                () -> {memberService.join(member1);
+                memberService.join(member2);
+        });
+    }
+
+}


### PR DESCRIPTION
기능
회원가입 테스트
중복 회원 예외처리 테스트

@Transactional: 반복 가능한 테스트 지원, 가각의 테스트를 실행할 때마다 트랜잭션을 시작하고 테스트가 끝나면 트랜잭션을 강제로 롤백
(테스트케이스에서 해당 어노테이션이 사용될 때만 롤백)