### PR TITLE
Order and OrderItem Development

### DIFF
--- a/shop/shop/src/main/java/com/min/shop/domain/Order.java
+++ b/shop/shop/src/main/java/com/min/shop/domain/Order.java
@@ -50,4 +50,41 @@ public class Order {
         this.delivery = delivery;
         delivery.setOrder(this);
     }
+
+    //생성 메서드
+    public static Order createOrder(Member member, Delivery delivery, OrderItem... orderItems) {
+        Order order = new Order();
+        order.setMember(member);
+        order.setDelivery(delivery);
+        for (OrderItem orderItem : orderItems) {
+            order.addOrderItem(orderItem);
+        }
+        order.setStatus(OrderStatus.ORDER);
+        order.setOrderDate(LocalDateTime.now());
+        return order;
+    }
+
+    //비즈니스로직
+    //주문취소
+    public void cancel() {
+        if (delivery.getStatus() == DeliveryStatus.COMP) {
+            throw new IllegalStateException("이미 배송완료된 상품은 취소가 불가능합니다.");
+        }
+
+        this.setStatus(OrderStatus.CANCEL);
+        for (OrderItem orderItem : orderItems) {
+            orderItem.cancel(); // 재고 다시 증가시키기(취소로 다시 들어왔으므로)
+        }
+    }
+
+    //조회로직
+    //전체 주문 가격 조회
+    public int getTotalPrice() {
+        int totalPrice = 0;
+        for (OrderItem orderItem : orderItems) {
+            totalPrice += orderItem.getTotalPrice();
+        }
+        return totalPrice;
+    }
+
 }

--- a/shop/shop/src/main/java/com/min/shop/domain/OrderItem.java
+++ b/shop/shop/src/main/java/com/min/shop/domain/OrderItem.java
@@ -26,4 +26,27 @@ public class OrderItem {
 
     private int orderPrice;
     private int count;
+
+    //생성 메서드
+    public static OrderItem createOrderItem(Item item, int orderPrice, int count) {
+        OrderItem orderItem = new OrderItem();
+        orderItem.setItem(item);
+        orderItem.setOrderPrice(orderPrice);
+        orderItem.setCount(count);
+
+        item.removeStock(count);
+        return orderItem;
+    }
+
+    //비즈니스 로직
+    //주문 취소
+    public void cancel() {
+        getItem().addStock(count);
+    }
+
+    //조회 로직
+    //주문상품 전체 가격 조회
+    public int getTotalPrice() {
+        return getOrderPrice() * getCount();
+    }
 }


### PR DESCRIPTION
주문
생성 메서드(createOrder()) : 주문 엔티티를 생성할 때 사용한다. 주문 회원, 배송정보, 주문상품의 정보를 받아 실제 주문 엔티티를 생성한다.
주문 취소(cancel()) : 주문 취소시 사용한다. 주문 상태를 취소로 변경하고 주문상품에 주문 취소를 알린다. 만약 이미 배송을 완료한 상품이면 주문을 취소하지 못하도록 예외를 발생시킨다.
전체 주문 가격 조회 : 주문시 사용한 전체 주문 가격을 조회한다. 전체 주문 가격을 알려면 각각의 주문상품 가격을 알아야 한다. 로직을 보면 연관된 주문 상품들의 가격을 조회해서 더한 값을 반환한다. (보통 실무에선 주문에 주문 가격 필드를 두고 역정규화 사용)

주문상품
생성 메서드(createOrderItem()) : 주문상품, 가격, 수량 정보를 사용하여 주문상품 엔티티를 생성한다.
주문 취소(cancel()) : getItem().addStock(count) 를 호출해서 취소한 주문 수량만큼 상품의 재고를 증가시킨다.
주문 가격 조회(getTotalPrice()) : 주문 가격에 수량을 곱한 값을 반환한다.